### PR TITLE
Search for deployment script in specified REPO_PATH_DIR

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 cd "$APP_DIR/$REPO_PATH_DIR"
 
 if [ ! -f start_service.sh ]; then
-    echo "The required file 'start_service.shy' is not found at $APP_DIR/$REPO_PATH_DIR" >&2
+    echo "The required file 'start_service.sh' is not found at $APP_DIR/$REPO_PATH_DIR" >&2
     exit 1
 fi
 ./start_service.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,10 @@
 
 set -e
 
-cd "${APP_DIR}"
+cd "$APP_DIR/$REPO_PATH_DIR"
+
+if [ ! -f start_service.sh ]; then
+    echo "The required file 'start_service.shy' is not found at $APP_DIR/$REPO_PATH_DIR" >&2
+    exit 1
+fi
 ./start_service.sh


### PR DESCRIPTION
Adapting the approach that is used in Civis's streamlit library here: https://github.com/civisanalytics/civis-services-streamlit/blob/main/entrypoint.sh#L7

This change is intended to make the Docker image more flexible for deployed services within Civis Platform, so that we can use it for arbitrary applications and directories. It still looks for an "start_service" shell script instead of just a Python app script, but that at least can be customized each user's need with this container.

Targeted for issue #5 